### PR TITLE
Fix LangGraph patterns: proper state returns

### DIFF
--- a/src/pocketagent/TravelAgent/agent.py
+++ b/src/pocketagent/TravelAgent/agent.py
@@ -1,5 +1,5 @@
 
-from langgraph.prebuilt import create_react_agent, ToolNode
+from langgraph.prebuilt import create_react_agent
 from langchain_core.tools import tool
 
 @tool
@@ -42,30 +42,20 @@ class TravelWeatherAgent:
             self.llm,
             tools=[find_hotel]
         )
-        self.weather_tools = ToolNode(tools=[get_weather])
-        self.travel_tools = ToolNode(tools=[find_hotel])
 
-    def router(self, state):
-        intent = getattr(state, "intent", None) or state.get("intent", None)
-        print(f"Travel Weather  Detected intent: {intent}")
-        if intent == "weather":
-            state["next"] = "weather"
-        elif intent == "travel":
-            state["next"] = "travel"
-        else:
-            state["next"] = "weather"  # default fallback
-        print(f"Travel Weather Routing to: {state['next']}")
-        return state
+    def _route_by_intent(self, state) -> str:
+        intent = state.get("intent", "weather")
+        dest = intent if intent in ("weather", "travel") else "weather"
+        print(f"TravelWeather routing to: {dest}")
+        return dest
 
     def get_graph(self):
         from langgraph.graph import StateGraph, START, END
         from ..state_types import S
         graph = StateGraph(S)
-        graph.add_node("router", self.router)
         graph.add_node("weather", self.weather_react_agent)
         graph.add_node("travel", self.travel_react_agent)
-        graph.add_edge(START, "router")
-        graph.add_conditional_edges("router", lambda s: s["next"], {"weather": "weather", "travel": "travel"})
+        graph.add_conditional_edges(START, self._route_by_intent, {"weather": "weather", "travel": "travel"})
         graph.add_edge("weather", END)
         graph.add_edge("travel", END)
         return graph.compile()

--- a/src/pocketagent/mcpagent/mcpagent.py
+++ b/src/pocketagent/mcpagent/mcpagent.py
@@ -1,32 +1,24 @@
-from langgraph.graph import StateGraph, START, END
-from langgraph.prebuilt import create_react_agent
-from langgraph.graph import StateGraph, MessagesState, START
+from langgraph.graph import StateGraph, START
 from langgraph.prebuilt import ToolNode, tools_condition
+from ..state_types import S
 
-# https://github.com/langchain-ai/langchain-mcp-adapters
+
 class MCPAgent:
-    def __init__(self, llm,tools):
-        self.llm = llm       
+    def __init__(self, llm, tools):
+        self.llm = llm
         self.tools = tools
 
-   
-
     def get_graph(self):
-        model = self.llm
+        def call_model(state: S):
+            response = self.llm.bind_tools(self.tools).invoke(state["messages"])
+            return {"messages": [response]}
 
-        # 4) Define the model node (sync function is fine inside the async graph)
-        def call_model(state: MessagesState,tools):
-            response = model.bind_tools(tools).invoke(state["messages"])
-            return {"messages": response}
-
-        # 5) Build the graph (be sure to NAME your nodes)
-        builder = StateGraph(MessagesState)
-        builder.add_node("call_model", lambda state: call_model(state, self.tools))
+        builder = StateGraph(S)
+        builder.add_node("call_model", call_model)
         builder.add_node("tools", ToolNode(self.tools))
 
         builder.add_edge(START, "call_model")
         builder.add_conditional_edges("call_model", tools_condition)
         builder.add_edge("tools", "call_model")
 
-        graph = builder.compile()
-        return graph
+        return builder.compile()

--- a/src/pocketagent/pocketagent_app.py
+++ b/src/pocketagent/pocketagent_app.py
@@ -3,14 +3,10 @@
 from langgraph.graph import StateGraph, START, END
 from langgraph.checkpoint.memory import MemorySaver
 
-# LangChain imports
-from langchain_core.messages import HumanMessage
-
 # PocketAgent imports
 from pocketagent import RouterNode, SmalltalkNode, S
 from pocketagent import ReturnAgent
 from pocketagent.TravelAgent.agent import TravelWeatherAgent
-
 
 
 class PocketAgentApp:
@@ -18,38 +14,44 @@ class PocketAgentApp:
         self.llm = llm
         self.emb = emb
         self.rag_agent = rag_agent
+        self.memory_saver = memory_saver if memory_saver is not None else MemorySaver()
         self.router_node_instance = RouterNode(llm=self.llm)
         self.smalltalk_node_instance = SmalltalkNode(llm=self.llm)
         self.travel_weather_agent = TravelWeatherAgent(llm=self.llm)
-        self.memory_saver = memory_saver if memory_saver is not None else MemorySaver()
         self.return_agent_instance = ReturnAgent(llm=self.llm, checkpointer=self.memory_saver)
         self.mcp_agent_instance = mcp_agent
-
-       
-
-    def chat(self, text: str, thread_id: str = "demo"):
-        config = {"configurable": {"thread_id": thread_id}}
-        out = self.app.invoke({"messages": [HumanMessage(content=text)], "intent": "", "thread_id": thread_id}, config)
-        return out["messages"][-1].content
+        self._compiled_graph = None
 
     def get_graph(self):
-        g = StateGraph(S)
-        g.add_node("router", self.router_node_instance.process)
-        g.add_node("smalltalk", self.smalltalk_node_instance.get_graph())
-        g.add_node("travel_weather", self.travel_weather_agent.get_graph())
-        g.add_node("rag_agent", self.rag_agent.get_graph())
-        g.add_node("return_agent_subgraph", self.return_agent_instance.get_graph())
-        g.add_node("mcp_agent", self.mcp_agent_instance.get_graph())
-        g.add_edge(START, "router")
-        g.add_conditional_edges("router", lambda s: s["intent"],
-            {"weather": "travel_weather", "travel": "travel_weather", "chitchat": "smalltalk", "rag": "rag_agent", "return_agent": "return_agent_subgraph", "mcp_agent": "mcp_agent"})
-        g.add_edge("rag_agent", END)
-        g.add_edge("smalltalk", END)
-        return  g.compile(checkpointer=self.memory_saver)
-    
-    
-    async def invoke(self,query) -> str:
-        print( f"Invoking PocketAgentApp with query: {query}" )
-        config = {"configurable": {"thread_id": "thread_id"}}
-        out  = await self.get_graph().ainvoke({"messages": [HumanMessage(content=query)]},config) 
+        if self._compiled_graph is None:
+            g = StateGraph(S)
+            g.add_node("router", self.router_node_instance.process)
+            g.add_node("smalltalk", self.smalltalk_node_instance.get_graph())
+            g.add_node("travel_weather", self.travel_weather_agent.get_graph())
+            g.add_node("rag_agent", self.rag_agent.get_graph())
+            g.add_node("return_agent_subgraph", self.return_agent_instance.get_graph())
+            g.add_node("mcp_agent", self.mcp_agent_instance.get_graph())
+            g.add_edge(START, "router")
+            g.add_conditional_edges("router", lambda s: s["intent"], {
+                "weather": "travel_weather",
+                "travel": "travel_weather",
+                "chitchat": "smalltalk",
+                "rag": "rag_agent",
+                "return_agent": "return_agent_subgraph",
+                "mcp_agent": "mcp_agent",
+            })
+            g.add_edge("rag_agent", END)
+            g.add_edge("smalltalk", END)
+            g.add_edge("travel_weather", END)
+            g.add_edge("return_agent_subgraph", END)
+            g.add_edge("mcp_agent", END)
+            self._compiled_graph = g.compile(checkpointer=self.memory_saver)
+        return self._compiled_graph
+
+    async def invoke(self, query) -> str:
+        from langchain_core.messages import HumanMessage
+        config = {"configurable": {"thread_id": "default"}}
+        out = await self.get_graph().ainvoke(
+            {"messages": [HumanMessage(content=query)]}, config
+        )
         return out["messages"][-1].content

--- a/src/pocketagent/ragagent/ragagent.py
+++ b/src/pocketagent/ragagent/ragagent.py
@@ -1,26 +1,22 @@
 
+from langchain_core.messages import AIMessage
 from ..state_types import S
+
 
 class RagAgent:
     def __init__(self, rag_bot_instance):
         self.rag_bot_instance = rag_bot_instance
-    # Wrapper around invoke to fit the node signature
-    def _process(self, state: S) -> S:
+
+    def _process(self, state: S) -> dict:
         msgs = state["messages"]
         user_msg = next((m.content for m in reversed(msgs) if getattr(m, "type", None) == "human"), "")
         inp = {"messages": [{"role": "user", "content": user_msg}]}
         cfg = {"configurable": {"thread_id": "tools-graph"}}
         out = self.rag_bot_instance.build_graph().invoke(inp, cfg)
-        from langchain_core.messages import AIMessage
-        state["messages"].append(AIMessage(content=out["answer"]))
-        return state
+        return {"messages": [AIMessage(content=out["answer"])]}
 
     def get_graph(self):
-        """
-        Returns a compiled LangGraph StateGraph object using _process as the node.
-        """
         from langgraph.graph import StateGraph, START, END
-        from ..state_types import S
         graph = StateGraph(S)
         graph.add_node("ragagent", self._process)
         graph.add_edge(START, "ragagent")

--- a/src/pocketagent/ragagent/ragbot.py
+++ b/src/pocketagent/ragagent/ragbot.py
@@ -75,7 +75,7 @@ class RAGBot:
     # (b) Retrieve
     def retrieve_node(self, state: RAGState) -> RAGState:
         q = state.get("condensed_question") or next((m["content"] for m in state["messages"] if m["role"] == "user"), "")
-        state["context"] = self.retriever.get_relevant_documents(q)
+        state["context"] = self.retriever.invoke(q)
         state.setdefault("checkpoints", []).append({"step": "retrieve", "state": dict(state)})
         return state
 

--- a/src/pocketagent/returnagent/wizardagent.py
+++ b/src/pocketagent/returnagent/wizardagent.py
@@ -26,7 +26,6 @@ class ReturnAgent:
         required_fields = ["email", "order_number"]
         all_fields_filled = all(field in answers and answers[field] for field in required_fields)
         confirmed = form_data.get("confirmed", False)
-        confirmed = True
         if all_fields_filled and confirmed:
             print("=== RETOUR-DATEN VOLLSTÄNDIG ===")
             print(f"Thread ID: {thread_id}")

--- a/src/pocketagent/router_node.py
+++ b/src/pocketagent/router_node.py
@@ -58,21 +58,21 @@ class RouterNode:
                 label = "chitchat"
 
         if "chitchat" in label or "smalltalk" in label:
-            state["intent"] = "chitchat"
-            state["chitchat"] = True
+            intent = "chitchat"
+            chitchat = True
         elif "rag" in label:
-            state["intent"] = "rag"
-            state["chitchat"] = False
+            intent = "rag"
+            chitchat = False
         elif "return_agent" in label:
-            state["intent"] = "return_agent"
-            state["chitchat"] = False
+            intent = "return_agent"
+            chitchat = False
         elif "mcp_agent" in label:
-            state["intent"] = "mcp_agent"
-            state["chitchat"] = False
+            intent = "mcp_agent"
+            chitchat = False
         else:
-            state["intent"] = "travel" if ("travel" in label or "hotel" in label) else "weather"
-            state["chitchat"] = False
+            intent = "travel" if ("travel" in label or "hotel" in label) else "weather"
+            chitchat = False
 
-        print(f"Classified intent: {state['intent']}")
-        return state
+        print(f"Classified intent: {intent}")
+        return {"intent": intent, "chitchat": chitchat}
 

--- a/src/pocketagent/smalltalk_agent/smalltalk_node.py
+++ b/src/pocketagent/smalltalk_agent/smalltalk_node.py
@@ -10,16 +10,7 @@ class SmalltalkNode:
             raise ValueError("llm parameter is required for SmalltalkNode")
         self.llm = llm
 
-    def _process(self, state: S) -> S:
-        """
-         Process the current state and generate a smalltalk response.
-
-        Args:
-            state: Current conversation state
-
-        Returns:
-            Updated state with AI response added
-        """
+    def _process(self, state: S) -> dict:
         msgs = state["messages"]
         last_user = next((m for m in reversed(msgs) if m.type == "human"), msgs[-1])
         q = last_user.content if isinstance(last_user.content, str) else ""
@@ -29,8 +20,7 @@ class SmalltalkNode:
             HumanMessage(content=q)
         ]).content
 
-        state["messages"].append(AIMessage(content=reply))
-        return state
+        return {"messages": [AIMessage(content=reply)]}
 
     def get_graph(self):
         """


### PR DESCRIPTION
## Summary
- All nodes return update dicts instead of mutating state directly — LangGraph reducers (`add_messages`) now work correctly with checkpointing/replay
- Cache compiled graph in `PocketAgentApp` instead of rebuilding on every request
- Fix deprecated `get_relevant_documents` → `retriever.invoke`
- MCPAgent: use `S` state type instead of `MessagesState` for consistency
- TravelWeatherAgent: remove phantom `next` state field, use `conditional_edges` from START
- Remove debug code (`confirmed = True`) in ReturnAgent
- Add missing END edges for travel_weather, return_agent, mcp_agent
- Clean up redundant imports

## Why
Nodes were mutating state via `state["messages"].append()` instead of returning `{"messages": [...]}`. This bypasses LangGraph's `add_messages` reducer and breaks checkpointing, replay, and streaming. The graph was also recompiled on every request instead of being cached.

## Test plan
- [ ] Verify RAG agent responds correctly
- [ ] Verify smalltalk routing works
- [ ] Verify return agent wizard flow
- [ ] Verify MCP agent tool calls
- [ ] Verify travel/weather routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)